### PR TITLE
fix(spark-k8s): fix slf4j-api conflit with low version

### DIFF
--- a/spark-k8s/Dockerfile
+++ b/spark-k8s/Dockerfile
@@ -24,8 +24,12 @@ configurations {
 }
 
 dependencies {
-    toCopy 'org.apache.spark:spark-hadoop-cloud_2.13:${PRODUCT_VERSION}'
-    toCopy 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.14.2'
+    toCopy('org.apache.spark:spark-hadoop-cloud_2.13:${PRODUCT_VERSION}') {
+        exclude group: 'org.slf4j', module: 'slf4j-api'
+    }
+    toCopy('com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.14.2') {
+        exclude group: 'org.slf4j', module: 'slf4j-api'
+    }
 }
 
 task download(type: Copy) {


### PR DESCRIPTION
Modify `spark-k8s/Dockerfile` to exclude `slf4j-api` when downloading dependencies using Gradle.

* **Dependency Exclusion**
  - Exclude `slf4j-api` from `org.apache.spark:spark-hadoop-cloud_2.13:${PRODUCT_VERSION}` dependency.
  - Exclude `slf4j-api` from `com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.14.2` dependency.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/whg517/zncdata-containers?shareId=8f350acd-3de5-4ad1-b859-b94eb2411596).